### PR TITLE
BING-52: add postinstall script for basetag hook

### DIFF
--- a/app/bingey-api/package.json
+++ b/app/bingey-api/package.json
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon server.js"
+    "start": "nodemon server.js",
+    "postinstall": "yarn basetag link"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Configure the Basetag  package to use absolute imports relative to the root directory

